### PR TITLE
Nix support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,13 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, flake-utils, nixpkgs, ... }:
+    flake-utils.lib.simpleFlake {
+      inherit self nixpkgs;
+      name = "MineMoebsie's factory game.";
+      shell = ./shell.nix;
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,35 @@
+{ pkgs ? import <nixpkgs> {} }:
+let
+  packages = ps: with ps; [
+    numpy
+    matplotlib
+    pygame
+    (
+      buildPythonPackage rec {
+        pname = "perlin_noise";
+        version = "1.12";
+        src = fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-AexC2fK8M4rlLtuwabN1+4P+xReE4XR5NmztH3BjlXw=";
+        };
+        doCheck = false;
+      }
+    )
+    (
+      buildPythonPackage rec {
+        pname = "easing_functions";
+        version = "1.0.4";
+        src = fetchPypi {
+          inherit pname version;
+          sha256 = "sha256-4Yx5MdRFuF8oxNFa0Kmke7ZdTi7vwNs4QESPriXj+d4=";
+        };
+        doCheck = false;
+        #propagatedBuildInputs = [
+        #];
+      }
+    )
+  ];
+  python = pkgs.python3.withPackages packages;
+in pkgs.mkShell {
+  buildInputs = [ python ];
+}


### PR DESCRIPTION
I added support for the nix package manager in this pull request. It uses [flake-utils](https://github.com/numtide/flake-utils) to create a development shell.
It's unfortunately not possible to read out the ``requirements.txt`` using this method, but it was the only approach I could find without restructuring the whole project. But I will maintain the ``shell.nix`` if you want me to.
It allows you to run ``nix develop`` in either the root of this project, or in any subdirectory, and that will install all the dependencies with nix patches.
